### PR TITLE
Include LICENSE in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.rst
+include LICENSE


### PR DESCRIPTION
Includes the license fail in MANIFEST.in so it will be in the package on pypi.

This is requested by conda forge, to which I am adding this package (https://github.com/conda-forge/staged-recipes/pull/10885).