### PR TITLE
Fix incorrect usages of NotImplemented

### DIFF
--- a/lunarcalendar/basefestival.py
+++ b/lunarcalendar/basefestival.py
@@ -35,14 +35,14 @@ class Festival(object):
         ''' get the first name in the target language '''
         lang = zh_map(lang)
         if lang not in self.langs:
-            raise NotImplemented
+            raise NotImplementedError
         return self.langs[lang][0]
 
     def get_lang_list(self, lang):
         ''' get the name list in the target language '''
         lang = zh_map(lang)
         if lang not in self.langs:
-            raise NotImplemented
+            raise NotImplementedError
         return self.langs[lang]
 
     def __call__(self, year):

--- a/lunarcalendar/converter.py
+++ b/lunarcalendar/converter.py
@@ -58,7 +58,7 @@ class Solar(object):
     def __eq__(self, other):
         _other = Converter.Lunar2Solar(other) if isinstance(other, Lunar) else other
         if not isinstance(_other, Solar):
-            raise NotImplemented
+            raise NotImplementedError
         return (self.year == _other.year and
                 self.month == _other.month and
                 self.day == _other.day)
@@ -97,7 +97,7 @@ class Lunar(object):
     def __eq__(self, other):
         _other = Converter.Solar2Lunar(other) if isinstance(other, Solar) else other
         if not isinstance(_other, Lunar):
-            raise NotImplemented
+            raise NotImplementedError
         return (self.year == _other.year and
                 self.month == _other.month and
                 self.day == _other.day and


### PR DESCRIPTION
This is an incorrect usage of `NotImplemented`. `NotImplemented` is a built-in constant used for binary special methods to indicate that there is not a implemented manner to handle a specific type.  ([see docs](https://l.facebook.com/l.php?u=https%3A%2F%2Fdocs.python.org%2F3.10%2Flibrary%2Fconstants.html%23NotImplemented&h=AT29x9fDYLjTC-QRD_xis3znno_iUs1Etkx25HegCbaRRNQ7ggVdxBz7VaafN_aGoigFO0iPQSLH2lDXm-pej-lNh1wNsa1SXO1Ck6XBBoezvXYOlEvculmjk5ydIKm7uJVuQAsFeWfhJyF01wcSzXZ6))

Essentially if you were to try `a.__add__(b)`, hitting a `NonImplemented` would allow for a try of `b.__add__(a)`.

Attempting to raise `NotImplemented` doesn't make sense as it is not an exception. `NotImplementedError` can be used instead

Example from repl:
```python
>>> raise NotImplemented
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: exceptions must derive from BaseException
>>> raise NotImplementedError
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NotImplementedError
```